### PR TITLE
Add base class for thrift Enums

### DIFF
--- a/compiler/cpp/src/generate/t_py_generator.cc
+++ b/compiler/cpp/src/generate/t_py_generator.cc
@@ -430,7 +430,7 @@ string t_py_generator::py_autogen_comment() {
  */
 string t_py_generator::py_imports() {
   return
-    string("from thrift.Thrift import TType, TMessageType, TException, TApplicationException");
+    string("from thrift.Thrift import TType, TMessageType, TException, TApplicationException, TEnum");
 }
 
 /**
@@ -462,8 +462,8 @@ void t_py_generator::generate_enum(t_enum* tenum) {
 
   f_types_ <<
     "class " << tenum->get_name() <<
-    (gen_newstyle_ ? "(object)" : "") <<
-    (gen_dynamic_ ? "(" + gen_dynbaseclass_ + ")" : "") <<
+    (gen_newstyle_ ? "(TEnum)" : "") <<
+    (gen_dynamic_ ? "(TEnum, " + gen_dynbaseclass_ + ")" : "") <<
     ":" << endl;
   indent_up();
   generate_python_docstring(f_types_, tenum);

--- a/lib/py/src/Thrift.py
+++ b/lib/py/src/Thrift.py
@@ -168,3 +168,14 @@ class TApplicationException(TException):
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
+
+
+class TEnum(object):
+
+    @classmethod
+    def get_name(cls, value):
+        return cls._VALUES_TO_NAMES[value]
+
+    @classmethod
+    def get_value(cls, name):
+        return cls._NAMES_TO_VALUES[name]


### PR DESCRIPTION
Instead of using _VALUES_TO_NAMES and _NAMES_TO_VALUES, add convenience methods to a base class. 